### PR TITLE
Remove References to GPL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,16 +25,15 @@ before submitting your changes as well.
 
 ## License of your contribution
 Unless specified otherwise, we assume your contribution is contributed under
-the same license as the rest of the project (GPLv3). If you wish to contribute
+the same license as the rest of the project (Apache 2.0). If you wish to contribute
 under another license, please make this clear in your pull request, and include
 the required edits to the readme. Your change will still need to be
-GPLv3-compatible, and we're likely to reject any pull request with a different
+Apache 2.0-compatible, and we're likely to reject any pull request with a different
 license unless there's a very good reason for doing so. A good reason might be
 if you are merging a significant amount of code from another project which uses
 another license, and you wish to ensure that the original project is able to
 merge back patches.
 
 If you need to pull in any extra dependencies, make sure these are licensed
-under a GPLv3-compatible license. This is the case for any library licensed
-under MIT, Apache v2, or both. Therefore, most libraries in the Rust FOSS
+under a Apache 2.0-compatible license. Most libraries in the Rust FOSS
 ecosystem should be fine.


### PR DESCRIPTION
Small text changes to remove references to GPL and replace with Apache 2.0
