### PR TITLE
Implement layer export and import more generically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ tar = "0.4"
 flate2 = "1.0"
 rayon = "1.4"
 thiserror = "1.0"
+async-trait = "0.1"
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/src/storage/cache.rs
+++ b/src/storage/cache.rs
@@ -90,8 +90,8 @@ impl LayerCache for LockingHashMapLayerCache {
 
 #[derive(Clone)]
 pub struct CachedLayerStore {
-    inner: Arc<dyn LayerStore>,
-    cache: Arc<dyn LayerCache>,
+    pub(crate) inner: Arc<dyn LayerStore>,
+    pub(crate) cache: Arc<dyn LayerCache>,
 }
 
 impl CachedLayerStore {
@@ -351,17 +351,6 @@ impl LayerStore for CachedLayerStore {
     ) -> Pin<Box<dyn Future<Output = io::Result<[u32; 5]>> + Send>> {
         let cache = self.cache.clone();
         self.rollup_upto_with_cache(layer, upto, cache)
-    }
-
-    fn export_layers(&self, layer_ids: Box<dyn Iterator<Item = [u32; 5]>>) -> Vec<u8> {
-        self.inner.export_layers(layer_ids)
-    }
-    fn import_layers(
-        &self,
-        pack: &[u8],
-        layer_ids: Box<dyn Iterator<Item = [u32; 5]>>,
-    ) -> Result<(), io::Error> {
-        self.inner.import_layers(pack, layer_ids)
     }
 
     fn layer_is_ancestor_of(

--- a/src/storage/directory.rs
+++ b/src/storage/directory.rs
@@ -1,21 +1,15 @@
 //! Directory-based implementation of storage traits.
 
 use bytes::{Bytes, BytesMut};
-use flate2::read::GzDecoder;
-use flate2::write::GzEncoder;
-use flate2::Compression;
 use futures::{future, Future};
 use locking::*;
-use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
-use std::io::{self, Read, Seek, SeekFrom};
+use std::io::{self, Seek, SeekFrom};
 use std::path::PathBuf;
 use std::pin::Pin;
-use tar::{self, Archive};
 use tokio::fs::{self, *};
 use tokio::io::{AsyncReadExt, AsyncWriteExt, BufWriter};
 
-use super::consts::*;
 use super::*;
 
 const PREFIX_DIR_SIZE: usize = 3;
@@ -148,8 +142,10 @@ impl PersistentLayerStore for DirectoryLayerStore {
         })
     }
 
-    fn create_directory(&self) -> Pin<Box<dyn Future<Output = io::Result<[u32; 5]>> + Send>> {
-        let name = rand::random();
+    fn create_named_directory(
+        &self,
+        name: [u32; 5],
+    ) -> Pin<Box<dyn Future<Output = io::Result<[u32; 5]>> + Send>> {
         let mut p = self.path.clone();
         let name_str = name_to_string(name);
         p.push(&name_str[0..PREFIX_DIR_SIZE]);
@@ -210,125 +206,6 @@ impl PersistentLayerStore for DirectoryLayerStore {
             }
         })
     }
-
-    fn export_layers(&self, layer_ids: Box<dyn Iterator<Item = [u32; 5]>>) -> Vec<u8> {
-        let path = &self.path;
-        let mut enc = GzEncoder::new(Vec::new(), Compression::default());
-        {
-            let mut tar = tar::Builder::new(&mut enc);
-            for id in layer_ids {
-                let id_string = name_to_string(id);
-                let mut layer_path: PathBuf = path.into();
-                let layer_id_prefix_dir = &id_string[0..PREFIX_DIR_SIZE];
-                layer_path.push(layer_id_prefix_dir);
-                layer_path.push(&id_string);
-
-                let mut tar_path = PathBuf::new();
-                tar_path.push(&id_string);
-                tar_append_layer(&mut tar, &tar_path, &layer_path).unwrap();
-            }
-            tar.finish().unwrap();
-        }
-        // TODO: Proper error handling
-        enc.finish().unwrap()
-    }
-    fn import_layers(
-        &self,
-        pack: &[u8],
-        layer_ids: Box<dyn Iterator<Item = [u32; 5]>>,
-    ) -> Result<(), io::Error> {
-        let cursor = io::Cursor::new(pack);
-        let tar = GzDecoder::new(cursor);
-        let mut archive = Archive::new(tar);
-
-        // collect layer ids into a set
-        let layer_id_set: HashSet<String> = layer_ids.map(name_to_string).collect();
-
-        // TODO we actually need to validate that these layers, when extracted, will make for a valid store.
-        // In terminus-server we are currently already doing this validation. Due to time constraints, we're not implementing it here.
-        //
-        // This should definitely be done in the future though, to make this part of the library independently usable in a safe manner.
-        for e in archive.entries()? {
-            let mut entry = e?;
-            let path = entry.path()?;
-
-            // check if entry is prefixed with a layer id we are interested in
-            let layer_id = path.iter().next().and_then(|p| p.to_str()).unwrap_or("");
-            if layer_id_set.contains(layer_id) {
-                let mut path: PathBuf = (&self.path).into();
-                let prefix = &layer_id[0..PREFIX_DIR_SIZE];
-                path.push(prefix);
-
-                // extract!
-                entry.unpack_in(path)?;
-            }
-        }
-
-        Ok(())
-    }
-}
-
-fn tar_append_file<W: io::Write>(
-    tar: &mut tar::Builder<W>,
-    destination: &PathBuf,
-    origin: &PathBuf,
-    file: &str,
-) -> io::Result<()> {
-    let file_path = origin.join(file);
-    tar.append_path_with_name(file_path, destination.join(file))
-}
-
-fn tar_append_file_if_exists<W: io::Write>(
-    tar: &mut tar::Builder<W>,
-    destination: &PathBuf,
-    origin: &PathBuf,
-    file: &str,
-) -> io::Result<()> {
-    let file_path = origin.join(file);
-    if file_path.exists() {
-        tar.append_path_with_name(file_path, destination.join(file))
-    } else {
-        Ok(())
-    }
-}
-
-fn tar_append_layer<W: io::Write>(
-    tar: &mut tar::Builder<W>,
-    tar_path: &PathBuf,
-    layer_path: &PathBuf,
-) -> io::Result<()> {
-    // this appends known layer files, excluding the rollup file.
-    tar.append_dir(tar_path, layer_path)?;
-
-    for f in &SHARED_REQUIRED_FILES {
-        tar_append_file(tar, tar_path, layer_path, f)?;
-    }
-    for f in &SHARED_OPTIONAL_FILES {
-        if f == &FILENAMES.rollup {
-            // skip the rollup file. It will not be resolvable remotely.
-            continue;
-        }
-        tar_append_file_if_exists(tar, tar_path, layer_path, f)?;
-    }
-    if layer_path.join(FILENAMES.parent).exists() {
-        // this is a child layer
-        for f in &CHILD_LAYER_REQUIRED_FILES {
-            tar_append_file(tar, tar_path, layer_path, f)?;
-        }
-        for f in &CHILD_LAYER_OPTIONAL_FILES {
-            tar_append_file_if_exists(tar, tar_path, layer_path, f)?;
-        }
-    } else {
-        // this is a base layer
-        for f in &BASE_LAYER_REQUIRED_FILES {
-            tar_append_file(tar, tar_path, layer_path, f)?;
-        }
-        for f in &BASE_LAYER_OPTIONAL_FILES {
-            tar_append_file_if_exists(tar, tar_path, layer_path, f)?;
-        }
-    }
-
-    Ok(())
 }
 
 #[derive(Clone)]
@@ -496,13 +373,6 @@ impl LabelStore for DirectoryLabelStore {
     }
 }
 
-#[derive(Debug)]
-pub enum PackError {
-    LayerNotFound,
-    Io(io::Error),
-    Utf8Error(std::str::Utf8Error),
-}
-
 impl Display for PackError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         write!(formatter, "{:?}", self)
@@ -518,47 +388,6 @@ impl From<std::str::Utf8Error> for PackError {
     fn from(err: std::str::Utf8Error) -> Self {
         Self::Utf8Error(err)
     }
-}
-
-pub fn pack_layer_parents<R: io::Read>(
-    readable: R,
-) -> Result<HashMap<[u32; 5], Option<[u32; 5]>>, PackError> {
-    let tar = GzDecoder::new(readable);
-    let mut archive = Archive::new(tar);
-
-    // build a set out of the layer ids for easy retrieval
-    let mut result_map = HashMap::new();
-
-    for e in archive.entries()? {
-        let mut entry = e?;
-        let path = entry.path()?;
-
-        let id = string_to_name(
-            path.iter()
-                .next()
-                .expect("expected path to have at least one component")
-                .to_str()
-                .expect("expected proper unicode path"),
-        )?;
-
-        if path.file_name().expect("expected path to have a filename") == "parent.hex" {
-            // this is an element we want to know the parent of
-            // lets read it
-            let mut parent_id_bytes = [0u8; 40];
-            entry.read_exact(&mut parent_id_bytes)?;
-            let parent_id_str = std::str::from_utf8(&parent_id_bytes)?;
-            let parent_id = string_to_name(parent_id_str)?;
-
-            result_map.insert(id, Some(parent_id));
-        } else if !result_map.contains_key(&id) {
-            // Ensure that an entry for this layer exists
-            // If we encounter the parent file later on, this'll be overwritten with the parent id.
-            // If not, it can be assumed to not have a parent.
-            result_map.insert(id, None);
-        }
-    }
-
-    Ok(result_map)
 }
 
 #[cfg(test)]
@@ -835,7 +664,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn export_import_layer_with_rollup() {
         let dir1 = tempdir().unwrap();
         let store1 = Arc::new(DirectoryLayerStore::new(dir1.path()));
@@ -863,13 +692,16 @@ mod tests {
         store1.clone().rollup(unrolled_layer).await.unwrap();
 
         let export =
-            LayerStore::export_layers(&*store1, Box::new(vec![base_name, child_name].into_iter()));
+            LayerStore::export_layers(&*store1, Box::new(vec![base_name, child_name].into_iter()))
+                .await
+                .unwrap();
 
         LayerStore::import_layers(
             &*store2,
             &export,
             Box::new(vec![base_name, child_name].into_iter()),
         )
+        .await
         .unwrap();
 
         let imported_layer = store2.get_layer(child_name).await.unwrap().unwrap();

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -193,10 +193,12 @@ impl PersistentLayerStore for MemoryLayerStore {
         Box::pin(async move { Ok(guard.await.keys().cloned().collect()) })
     }
 
-    fn create_directory(&self) -> Pin<Box<dyn Future<Output = io::Result<[u32; 5]>> + Send>> {
+    fn create_named_directory(
+        &self,
+        name: [u32; 5],
+    ) -> Pin<Box<dyn Future<Output = io::Result<[u32; 5]>> + Send>> {
         let guard = self.layers.write();
         Box::pin(async move {
-            let name: [u32; 5] = rand::random();
             guard.await.insert(name, HashMap::new());
 
             Ok(name)
@@ -256,18 +258,6 @@ impl PersistentLayerStore for MemoryLayerStore {
                 Err(io::Error::new(io::ErrorKind::NotFound, "layer not found"))
             }
         })
-    }
-
-    fn export_layers(&self, _layer_ids: Box<dyn Iterator<Item = [u32; 5]>>) -> Vec<u8> {
-        todo!();
-    }
-
-    fn import_layers(
-        &self,
-        _pack: &[u8],
-        _layer_ids: Box<dyn Iterator<Item = [u32; 5]>>,
-    ) -> Result<(), io::Error> {
-        todo!();
     }
 }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -32,9 +32,11 @@ mod layer;
 pub mod delta;
 mod locking;
 pub mod memory;
+pub mod pack;
 
 pub use cache::*;
 pub use delta::*;
 pub use file::*;
 pub use label::*;
 pub use layer::*;
+pub use pack::*;

--- a/src/storage/pack.rs
+++ b/src/storage/pack.rs
@@ -267,14 +267,9 @@ pub fn pack_layer_parents<R: io::Read>(
     // build a set out of the layer ids for easy retrieval
     let mut result_map = HashMap::new();
 
-    println!("about to go into loop");
     for e in archive.entries()? {
-        println!("a");
         let mut entry = e?;
-        println!("b");
         let path = entry.path()?;
-        println!("c");
-        println!("path: {:?}", path);
 
         let id = string_to_name(
             path.iter()
@@ -285,7 +280,6 @@ pub fn pack_layer_parents<R: io::Read>(
         )?;
 
         if path.file_name().expect("expected path to have a filename") == "parent.hex" {
-            println!("hello a");
             // this is an element we want to know the parent of
             // lets read it
             let mut parent_id_bytes = [0u8; 40];
@@ -295,7 +289,6 @@ pub fn pack_layer_parents<R: io::Read>(
 
             result_map.insert(id, Some(parent_id));
         } else if !result_map.contains_key(&id) {
-            println!("hello b");
             // Ensure that an entry for this layer exists
             // If we encounter the parent file later on, this'll be overwritten with the parent id.
             // If not, it can be assumed to not have a parent.

--- a/src/storage/pack.rs
+++ b/src/storage/pack.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::fmt::Display;
 use std::io::{self, Read};
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -240,6 +241,23 @@ pub enum PackError {
     Utf8Error(std::str::Utf8Error),
 }
 
+impl Display for PackError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        write!(formatter, "{:?}", self)
+    }
+}
+
+impl From<io::Error> for PackError {
+    fn from(err: io::Error) -> Self {
+        Self::Io(err)
+    }
+}
+impl From<std::str::Utf8Error> for PackError {
+    fn from(err: std::str::Utf8Error) -> Self {
+        Self::Utf8Error(err)
+    }
+}
+
 pub fn pack_layer_parents<R: io::Read>(
     readable: R,
 ) -> Result<HashMap<[u32; 5], Option<[u32; 5]>>, PackError> {
@@ -303,5 +321,68 @@ impl Packable for CachedLayerStore {
         layer_ids: Box<dyn Iterator<Item = [u32; 5]> + Send>,
     ) -> io::Result<()> {
         self.inner.import_layers(pack, layer_ids).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layer::*;
+    use crate::storage::directory::*;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn export_import_layer_with_rollup() {
+        let dir1 = tempdir().unwrap();
+        let store1 = Arc::new(DirectoryLayerStore::new(dir1.path()));
+        let dir2 = tempdir().unwrap();
+        let store2 = Arc::new(DirectoryLayerStore::new(dir2.path()));
+
+        let mut builder = store1.create_base_layer().await.unwrap();
+        let base_name = builder.name();
+
+        builder.add_string_triple(StringTriple::new_node("cow", "likes", "duck"));
+        builder.add_string_triple(StringTriple::new_node("duck", "hates", "cow"));
+
+        builder.commit_boxed().await.unwrap();
+
+        let mut builder = store1.create_child_layer(base_name).await.unwrap();
+        let child_name = builder.name();
+
+        builder.remove_string_triple(StringTriple::new_node("duck", "hates", "cow"));
+        builder.add_string_triple(StringTriple::new_node("duck", "likes", "cow"));
+
+        builder.commit_boxed().await.unwrap();
+
+        let unrolled_layer = store1.get_layer(child_name).await.unwrap().unwrap();
+
+        store1.clone().rollup(unrolled_layer).await.unwrap();
+
+        let export =
+            LayerStore::export_layers(&*store1, Box::new(vec![base_name, child_name].into_iter()))
+                .await
+                .unwrap();
+
+        LayerStore::import_layers(
+            &*store2,
+            &export,
+            Box::new(vec![base_name, child_name].into_iter()),
+        )
+        .await
+        .unwrap();
+
+        let imported_layer = store2.get_layer(child_name).await.unwrap().unwrap();
+        let triples: Vec<_> = imported_layer
+            .triples()
+            .map(|t| imported_layer.id_triple_to_string(&t).unwrap())
+            .collect();
+        assert_eq!(
+            vec![
+                StringTriple::new_node("cow", "likes", "duck"),
+                StringTriple::new_node("duck", "likes", "cow")
+            ],
+            triples
+        );
     }
 }

--- a/src/storage/pack.rs
+++ b/src/storage/pack.rs
@@ -1,0 +1,87 @@
+use std::io;
+use std::path::PathBuf;
+
+use super::layer::*;
+use super::consts::*;
+
+pub trait Packable {
+    /// Export the given layers by creating a pack, a Vec<u8> that can later be used with `import_layers` on a different store.
+    fn export_layers(&self, layer_ids: Box<dyn Iterator<Item = [u32; 5]>>) -> Vec<u8>;
+
+    /// Import the specified layers from the given pack, a byte slice that was previously generated with `export_layers`, on another store, and possibly even another machine).
+    ///
+    /// After this operation, the specified layers will be retrievable
+    /// from this store, provided they existed in the pack. specified
+    /// layers that are not in the pack are silently ignored.
+    fn import_layers(
+        &self,
+        pack: &[u8],
+        layer_ids: Box<dyn Iterator<Item = [u32; 5]>>,
+    ) -> Result<(), io::Error>;
+}
+
+
+
+fn tar_append_file<W: io::Write>(
+    tar: &mut tar::Builder<W>,
+    destination: &PathBuf,
+    origin: &PathBuf,
+    file: &str,
+) -> io::Result<()> {
+    let file_path = origin.join(file);
+    tar.append_path_with_name(file_path, destination.join(file))
+}
+
+fn tar_append_file_if_exists<W: io::Write>(
+    tar: &mut tar::Builder<W>,
+    destination: &PathBuf,
+    origin: &PathBuf,
+    file: &str,
+) -> io::Result<()> {
+    let file_path = origin.join(file);
+    if file_path.exists() {
+        tar.append_path_with_name(file_path, destination.join(file))
+    } else {
+        Ok(())
+    }
+}
+
+fn tar_append_layer<W: io::Write>(
+    tar: &mut tar::Builder<W>,
+    tar_path: &PathBuf,
+    layer_path: &PathBuf,
+) -> io::Result<()> {
+    // this appends known layer files, excluding the rollup file.
+    tar.append_dir(tar_path, layer_path)?;
+
+    for f in &SHARED_REQUIRED_FILES {
+        tar_append_file(tar, tar_path, layer_path, f)?;
+    }
+    for f in &SHARED_OPTIONAL_FILES {
+        if f == &FILENAMES.rollup {
+            // skip the rollup file. It will not be resolvable remotely.
+            continue;
+        }
+        tar_append_file_if_exists(tar, tar_path, layer_path, f)?;
+    }
+    if layer_path.join(FILENAMES.parent).exists() {
+        // this is a child layer
+        for f in &CHILD_LAYER_REQUIRED_FILES {
+            tar_append_file(tar, tar_path, layer_path, f)?;
+        }
+        for f in &CHILD_LAYER_OPTIONAL_FILES {
+            tar_append_file_if_exists(tar, tar_path, layer_path, f)?;
+        }
+    } else {
+        // this is a base layer
+        for f in &BASE_LAYER_REQUIRED_FILES {
+            tar_append_file(tar, tar_path, layer_path, f)?;
+        }
+        for f in &BASE_LAYER_OPTIONAL_FILES {
+            tar_append_file_if_exists(tar, tar_path, layer_path, f)?;
+        }
+    }
+
+    Ok(())
+}
+

--- a/src/storage/pack.rs
+++ b/src/storage/pack.rs
@@ -1,87 +1,168 @@
 use std::io;
 use std::path::PathBuf;
+use std::pin::Pin;
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use super::layer::*;
+use futures::Future;
+
 use super::consts::*;
+use super::file::*;
+use super::layer::*;
+
+use tar::*;
+//use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
 
 pub trait Packable {
     /// Export the given layers by creating a pack, a Vec<u8> that can later be used with `import_layers` on a different store.
-    fn export_layers(&self, layer_ids: Box<dyn Iterator<Item = [u32; 5]>>) -> Vec<u8>;
+    fn export_layers<'a>(
+        &'a self,
+        layer_ids: Box<dyn Iterator<Item = [u32; 5]> + Send>,
+    ) -> Pin<Box<dyn Future<Output = io::Result<Vec<u8>>> + Send + 'a>>;
 
     /// Import the specified layers from the given pack, a byte slice that was previously generated with `export_layers`, on another store, and possibly even another machine).
     ///
     /// After this operation, the specified layers will be retrievable
     /// from this store, provided they existed in the pack. specified
     /// layers that are not in the pack are silently ignored.
-    fn import_layers(
-        &self,
+    fn import_layers<'a>(
+        &'a self,
         pack: &[u8],
         layer_ids: Box<dyn Iterator<Item = [u32; 5]>>,
-    ) -> Result<(), io::Error>;
+    ) -> Pin<Box<dyn Future<Output = io::Result<()>> + Send + 'a>>;
 }
 
+impl<T: PersistentLayerStore> Packable for T {
+    fn export_layers<'a>(
+        &'a self,
+        layer_ids: Box<dyn Iterator<Item = [u32; 5]> + Send>,
+    ) -> Pin<Box<dyn Future<Output = io::Result<Vec<u8>>> + Send + 'a>> {
+        let mtime = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        Box::pin(async move {
+            let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+            {
+                let mut tar = tar::Builder::new(&mut enc);
+                for id in layer_ids {
+                    tar_append_layer(&mut tar, self, id, mtime).await?;
+                }
+                tar.finish().unwrap();
+            }
+            // TODO: Proper error handling
+            Ok(enc.finish().unwrap())
+        })
+    }
 
-
-fn tar_append_file<W: io::Write>(
-    tar: &mut tar::Builder<W>,
-    destination: &PathBuf,
-    origin: &PathBuf,
-    file: &str,
-) -> io::Result<()> {
-    let file_path = origin.join(file);
-    tar.append_path_with_name(file_path, destination.join(file))
-}
-
-fn tar_append_file_if_exists<W: io::Write>(
-    tar: &mut tar::Builder<W>,
-    destination: &PathBuf,
-    origin: &PathBuf,
-    file: &str,
-) -> io::Result<()> {
-    let file_path = origin.join(file);
-    if file_path.exists() {
-        tar.append_path_with_name(file_path, destination.join(file))
-    } else {
-        Ok(())
+    fn import_layers<'a>(
+        &'a self,
+        _pack: &[u8],
+        _layer_ids: Box<dyn Iterator<Item = [u32; 5]>>,
+    ) -> Pin<Box<dyn Future<Output = io::Result<()>> + Send + 'a>> {
+        todo!();
     }
 }
 
-fn tar_append_layer<W: io::Write>(
+async fn tar_append_file<S: PersistentLayerStore, W: io::Write>(
+    store: &S,
     tar: &mut tar::Builder<W>,
-    tar_path: &PathBuf,
+    layer: [u32; 5],
     layer_path: &PathBuf,
+    file_name: &str,
+    mtime: u64,
 ) -> io::Result<()> {
-    // this appends known layer files, excluding the rollup file.
-    tar.append_dir(tar_path, layer_path)?;
+    if store.file_exists(layer, file_name).await? {
+        let file = store.get_file(layer, file_name).await?;
+        let contents = file.map().await?;
+        let cursor = io::Cursor::new(&contents);
+
+        let path = layer_path.join(file_name);
+
+        let mut header = Header::new_gnu();
+        header.set_mode(0o644);
+        header.set_size(file.size() as u64);
+        header.set_mtime(mtime);
+        tar.append_data(&mut header, path, cursor).unwrap();
+
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "file does not exist",
+        ))
+    }
+}
+
+async fn tar_append_file_if_exists<S: PersistentLayerStore, W: io::Write>(
+    store: &S,
+    tar: &mut tar::Builder<W>,
+    layer: [u32; 5],
+    layer_path: &PathBuf,
+    file_name: &str,
+    mtime: u64,
+) -> io::Result<()> {
+    if store.file_exists(layer, file_name).await? {
+        let file = store.get_file(layer, file_name).await?;
+        let contents = file.map().await?;
+        let cursor = io::Cursor::new(&contents);
+
+        let path = layer_path.join(file_name);
+
+        let mut header = Header::new_gnu();
+        header.set_mode(0o644);
+        header.set_size(file.size() as u64);
+        header.set_mtime(mtime);
+        tar.append_data(&mut header, path, cursor).unwrap();
+    }
+
+    Ok(())
+}
+
+async fn tar_append_layer<W: io::Write, S: PersistentLayerStore>(
+    tar: &mut tar::Builder<W>,
+    store: &S,
+    layer: [u32; 5],
+    mtime: u64,
+) -> io::Result<()> {
+    let mut header = Header::new_gnu();
+    header.set_mode(0o755);
+    header.set_entry_type(EntryType::Directory);
+    header.set_mtime(mtime);
+    let layer_name = name_to_string(layer);
+    let mut path = PathBuf::new();
+    path.push(layer_name);
+    tar.append_data(&mut header, &path, std::io::empty())
+        .unwrap();
 
     for f in &SHARED_REQUIRED_FILES {
-        tar_append_file(tar, tar_path, layer_path, f)?;
+        tar_append_file(store, tar, layer, &path, f, mtime).await?;
     }
     for f in &SHARED_OPTIONAL_FILES {
         if f == &FILENAMES.rollup {
             // skip the rollup file. It will not be resolvable remotely.
             continue;
         }
-        tar_append_file_if_exists(tar, tar_path, layer_path, f)?;
+        tar_append_file_if_exists(store, tar, layer, &path, f, mtime).await?;
     }
-    if layer_path.join(FILENAMES.parent).exists() {
+    if store.file_exists(layer, FILENAMES.parent).await? {
         // this is a child layer
         for f in &CHILD_LAYER_REQUIRED_FILES {
-            tar_append_file(tar, tar_path, layer_path, f)?;
+            tar_append_file(store, tar, layer, &path, f, mtime).await?;
         }
         for f in &CHILD_LAYER_OPTIONAL_FILES {
-            tar_append_file_if_exists(tar, tar_path, layer_path, f)?;
+            tar_append_file_if_exists(store, tar, layer, &path, f, mtime).await?;
         }
     } else {
         // this is a base layer
         for f in &BASE_LAYER_REQUIRED_FILES {
-            tar_append_file(tar, tar_path, layer_path, f)?;
+            tar_append_file(store, tar, layer, &path, f, mtime).await?;
         }
         for f in &BASE_LAYER_OPTIONAL_FILES {
-            tar_append_file_if_exists(tar, tar_path, layer_path, f)?;
+            tar_append_file_if_exists(store, tar, layer, &path, f, mtime).await?;
         }
     }
 
     Ok(())
 }
-

--- a/src/storage/pack.rs
+++ b/src/storage/pack.rs
@@ -288,11 +288,11 @@ pub fn pack_layer_parents<R: io::Read>(
             let parent_id = string_to_name(parent_id_str)?;
 
             result_map.insert(id, Some(parent_id));
-        } else if !result_map.contains_key(&id) {
+        } else {
             // Ensure that an entry for this layer exists
             // If we encounter the parent file later on, this'll be overwritten with the parent id.
             // If not, it can be assumed to not have a parent.
-            result_map.insert(id, None);
+            result_map.entry(id).or_insert(None);
         }
     }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -763,8 +763,11 @@ impl Store {
     }
 
     /// Export the given layers by creating a pack, a Vec<u8> that can later be used with `import_layers` on a different store.
-    pub fn export_layers(&self, layer_ids: Box<dyn Iterator<Item = [u32; 5]>>) -> Vec<u8> {
-        self.layer_store.export_layers(layer_ids)
+    pub async fn export_layers(
+        &self,
+        layer_ids: Box<dyn Iterator<Item = [u32; 5]> + Send>,
+    ) -> io::Result<Vec<u8>> {
+        self.layer_store.export_layers(layer_ids).await
     }
 
     /// Import the specified layers from the given pack, a byte slice that was previously generated with `export_layers`, on another store, and possibly even another machine).
@@ -772,12 +775,12 @@ impl Store {
     /// After this operation, the specified layers will be retrievable
     /// from this store, provided they existed in the pack. specified
     /// layers that are not in the pack are silently ignored.
-    pub fn import_layers(
-        &self,
-        pack: &[u8],
-        layer_ids: Box<dyn Iterator<Item = [u32; 5]>>,
-    ) -> Result<(), io::Error> {
-        self.layer_store.import_layers(pack, layer_ids)
+    pub async fn import_layers<'a>(
+        &'a self,
+        pack: &'a [u8],
+        layer_ids: Box<dyn Iterator<Item = [u32; 5]> + Send>,
+    ) -> io::Result<()> {
+        self.layer_store.import_layers(pack, layer_ids).await
     }
 }
 

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -514,8 +514,11 @@ impl SyncStore {
     }
 
     /// Export the given layers by creating a pack, a Vec<u8> that can later be used with `import_layers` on a different store.
-    pub fn export_layers(&self, layer_ids: Box<dyn Iterator<Item = [u32; 5]>>) -> Vec<u8> {
-        self.inner.layer_store.export_layers(layer_ids)
+    pub fn export_layers(
+        &self,
+        layer_ids: Box<dyn Iterator<Item = [u32; 5]> + Send>,
+    ) -> io::Result<Vec<u8>> {
+        task_sync(self.inner.layer_store.export_layers(layer_ids))
     }
 
     /// Import the specified layers from the given pack, a byte slice that was previously generated with `export_layers`, on another store, and possibly even another machine).
@@ -526,9 +529,9 @@ impl SyncStore {
     pub fn import_layers(
         &self,
         pack: &[u8],
-        layer_ids: Box<dyn Iterator<Item = [u32; 5]>>,
-    ) -> Result<(), io::Error> {
-        self.inner.layer_store.import_layers(pack, layer_ids)
+        layer_ids: Box<dyn Iterator<Item = [u32; 5]> + Send>,
+    ) -> io::Result<()> {
+        task_sync(self.inner.layer_store.import_layers(pack, layer_ids))
     }
 }
 
@@ -645,7 +648,7 @@ mod tests {
         assert!(builder.committed());
     }
 
-    use crate::storage::directory::pack_layer_parents;
+    use crate::storage::pack::pack_layer_parents;
     #[test]
     fn export_and_import_pack() {
         let dir1 = tempdir().unwrap();
@@ -673,7 +676,11 @@ mod tests {
         let layer3 = builder3.commit().unwrap();
 
         let ids = vec![layer1.name(), layer2.name(), layer3.name()];
-        let pack = store1.export_layers(Box::new(ids.clone().into_iter()));
+        let pack = store1
+            .export_layers(Box::new(ids.clone().into_iter()))
+            .unwrap();
+
+        println!("pack: {:?}", pack);
 
         let parents_map = pack_layer_parents(io::Cursor::new(&pack)).unwrap();
 

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -680,8 +680,6 @@ mod tests {
             .export_layers(Box::new(ids.clone().into_iter()))
             .unwrap();
 
-        println!("pack: {:?}", pack);
-
         let parents_map = pack_layer_parents(io::Cursor::new(&pack)).unwrap();
 
         assert_eq!(3, parents_map.len());


### PR DESCRIPTION
This implements layer export and import for the PersistentLayerStore, which currently backs both the memory and the directory layer store (yes it is a bit of a misnomer).

This closes #58. It is also an initial step towards #62, implementing the pack functionality as a separate trait in its own file instead of as part of a bigger trait. It also makes use of the `async_trait` macro as mentioned in #56.