### PR TITLE
Label versioned update

### DIFF
--- a/src/storage/locking.rs
+++ b/src/storage/locking.rs
@@ -198,6 +198,14 @@ impl ExclusiveLockedFile {
         })
     }
 
+    pub async fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        let file = self
+            .file
+            .as_mut()
+            .expect("tried to truncate a dropped file");
+        file.seek(pos).await
+    }
+
     pub async fn truncate(&mut self) -> io::Result<()> {
         let file = self
             .file

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -719,7 +719,7 @@ impl NamedGraph {
     }
 
     /// Set the database label to the given layer, even if it is not a valid ancestor.
-    pub async fn force_set_head(&self, layer: &StoreLayer) -> io::Result<bool> {
+    pub async fn force_set_head(&self, layer: &StoreLayer) -> io::Result<()> {
         let layer_name = layer.name();
         let label = self.store.label_store.get_label(&self.label).await?;
         match label {
@@ -727,7 +727,7 @@ impl NamedGraph {
             Some(label) => {
                 self.store.label_store.set_label(&label, layer_name).await?;
 
-                Ok(true)
+                Ok(())
             }
         }
     }
@@ -917,7 +917,7 @@ mod tests {
 
         let layer2 = builder2.commit().await.unwrap();
 
-        assert!(database.force_set_head(&layer2).await.unwrap());
+        database.force_set_head(&layer2).await.unwrap();
 
         let new_layer = database.head().await.unwrap().unwrap();
 

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -449,8 +449,15 @@ impl SyncNamedGraph {
         self.inner.name()
     }
 
+    /// Returns the layer this database points at, as well as the label version.
+    pub fn head_version(&self) -> io::Result<(Option<SyncStoreLayer>, u64)> {
+        let inner = task_sync(self.inner.head_version());
+
+        inner.map(|(layer, version)| (layer.map(SyncStoreLayer::wrap), version))
+    }
+
     /// Returns the layer this database points at.
-    pub fn head(&self) -> Result<Option<SyncStoreLayer>, io::Error> {
+    pub fn head(&self) -> io::Result<Option<SyncStoreLayer>> {
         let inner = task_sync(self.inner.head());
 
         inner.map(|i| i.map(SyncStoreLayer::wrap))

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -469,7 +469,7 @@ impl SyncNamedGraph {
     }
 
     /// Set the database label to the given layer if it is a valid ancestor, returning false otherwise.
-    pub fn force_set_head(&self, layer: &SyncStoreLayer) -> Result<bool, io::Error> {
+    pub fn force_set_head(&self, layer: &SyncStoreLayer) -> Result<(), io::Error> {
         task_sync(self.inner.force_set_head(&layer.inner))
     }
 }

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -468,9 +468,14 @@ impl SyncNamedGraph {
         task_sync(self.inner.set_head(&layer.inner))
     }
 
-    /// Set the database label to the given layer if it is a valid ancestor, returning false otherwise.
+    /// Set the database label to the given layer, even if it is not a valid ancestor.
     pub fn force_set_head(&self, layer: &SyncStoreLayer) -> Result<(), io::Error> {
         task_sync(self.inner.force_set_head(&layer.inner))
+    }
+
+    /// Set the database label to the given layer, even if it is not a valid ancestor. Also checks given version, and if it doesn't match, the update won't happen and false will be returned.
+    pub fn force_set_head_version(&self, layer: &SyncStoreLayer, version: u64) -> io::Result<bool> {
+        task_sync(self.inner.force_set_head_version(&layer.inner, version))
     }
 }
 


### PR DESCRIPTION
New methods in the store api which provide a way to retrieve the head graph layer and its version, and replace the current graph head as long as given version matches.

Closes #65. 