### PR TITLE
Fix rollup

### DIFF
--- a/src/layer/id_map.rs
+++ b/src/layer/id_map.rs
@@ -189,7 +189,7 @@ async fn construct_idmaps_from_layers<F: 'static + FileLoad + FileStore>(
 
     let predicate_idmaps: Vec<_> = layers
         .iter()
-        .map(|layer| layer.node_value_id_map().clone())
+        .map(|layer| layer.predicate_id_map().clone())
         .collect();
 
     construct_idmaps_from_structures(

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -299,7 +299,7 @@ impl StoreLayer {
         // TODO: This is awkward, we should have a way to get the internal layer
         let layer_opt = store1.get_layer(self.name()).await?;
         let layer =
-            layer_opt.ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "label not found"))?;
+            layer_opt.ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "layer not found"))?;
         let store2 = self.store.layer_store.clone();
         store2.rollup(layer).await?;
         Ok(())


### PR DESCRIPTION
Due to a coding error, when rolling up a stack of layers where one was previously rolled up, the node-value idmap was used instead of the predicate idmap, causing a lot of indexes to be wrongly mapped.

This pull request fixes that.