### PR TITLE
Implement a way to compare layers which fails on delta rollups

### DIFF
--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -539,6 +539,14 @@ impl StoreLayer {
     }
 }
 
+impl PartialEq for StoreLayer {
+    fn eq(&self, other: &StoreLayer) -> bool {
+        Arc::ptr_eq(&self.layer, &other.layer)
+    }
+}
+
+impl Eq for StoreLayer {}
+
 impl Layer for StoreLayer {
     fn name(&self) -> [u32; 5] {
         self.layer.name()

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -339,6 +339,14 @@ impl SyncStoreLayer {
     }
 }
 
+impl PartialEq for SyncStoreLayer {
+    fn eq(&self, other: &SyncStoreLayer) -> bool {
+        self.inner.eq(&other.inner)
+    }
+}
+
+impl Eq for SyncStoreLayer {}
+
 impl Layer for SyncStoreLayer {
     fn name(&self) -> [u32; 5] {
         self.inner.name()


### PR DESCRIPTION
It was previously not possible to compare two layers. Now it is.