### PR TITLE
Optimizations to BitIndex

### DIFF
--- a/src/structure/bitarray.rs
+++ b/src/structure/bitarray.rs
@@ -186,7 +186,7 @@ impl BitArray {
     /// Panics if `index` is >= the length of the bit array.
     pub fn get(&self, index: usize) -> bool {
         let len = self.len();
-        assert!(index < len, "expected index ({}) < length ({})", index, len);
+        debug_assert!(index < len, "expected index ({}) < length ({})", index, len);
 
         let byte = self.buf[index / 8];
         let mask = 0b1000_0000 >> index % 8;

--- a/src/structure/bitindex.rs
+++ b/src/structure/bitindex.rs
@@ -20,7 +20,7 @@ const SBLOCK_SIZE: usize = 52;
 /// Calculate if it is a good idea to use a linear bitscan instead of the bitindex.
 /// We are assuming that this is the case if the start and end indexes are on the same cache line.
 #[inline(always)]
-fn use_linear_bitscan(start: usize, end: usize) -> bool {
+fn use_linear_bitscan(start: u64, end: u64) -> bool {
     start / (8 * 64) == end / (8 * 64)
 }
 
@@ -164,10 +164,7 @@ impl BitIndex {
     }
 
     fn select1_from_range_opt(&self, subrank: u64, start: u64, end: Option<u64>) -> Option<u64> {
-        if use_linear_bitscan(
-            start as usize,
-            end.unwrap_or(self.array.len() as u64) as usize,
-        ) {
+        if use_linear_bitscan(start, end.unwrap_or(self.len() as u64)) {
             return self.select_from_range_opt_linear(subrank, start, end, true);
         }
 
@@ -226,7 +223,7 @@ impl BitIndex {
         }
 
         if subrank == 0 {
-            if self.array.get(start as usize) == find {
+            if self.get(start) == find {
                 return None;
             } else {
                 return Some(start);
@@ -234,12 +231,12 @@ impl BitIndex {
         }
 
         let end = match end {
-            Some(end) => end as usize,
-            None => self.array.len(),
+            Some(end) => end,
+            None => self.len() as u64,
         };
 
-        for i in start as usize..end {
-            if self.array.get(i) == find {
+        for i in start..end {
+            if self.get(i) == find {
                 subrank -= 1;
 
                 if subrank == 0 {
@@ -342,10 +339,7 @@ impl BitIndex {
         start: u64,
         end: Option<u64>,
     ) -> Option<u64> {
-        if use_linear_bitscan(
-            start as usize,
-            end.unwrap_or(self.array.len() as u64) as usize,
-        ) {
+        if use_linear_bitscan(start, end.unwrap_or(self.len() as u64)) {
             return self.select_from_range_opt_linear(subrank, start, end, false);
         }
 

--- a/src/structure/bitindex.rs
+++ b/src/structure/bitindex.rs
@@ -16,7 +16,6 @@ use tokio::io::AsyncRead;
 
 /// The amount of 64-bit blocks that go into a superblock.
 const SBLOCK_SIZE: usize = 52;
-const BITS_LINEAR_SCAN_THRESHOLD: usize = 100;
 
 /// Calculate if it is a good idea to use a linear bitscan instead of the bitindex.
 /// We are assuming that this is the case if the start and end indexes are on the same cache line.
@@ -215,7 +214,6 @@ impl BitIndex {
         None
     }
 
-    #[inline(never)]
     fn select_from_range_opt_linear(
         &self,
         mut subrank: u64,

--- a/src/structure/logarray.rs
+++ b/src/structure/logarray.rs
@@ -223,7 +223,7 @@ impl LogArray {
     ///
     /// Panics if `index` is >= the length of the log array.
     pub fn entry(&self, index: usize) -> u64 {
-        assert!(
+        debug_assert!(
             index < self.len(),
             "expected index ({}) < length ({})",
             index,


### PR DESCRIPTION
This pull request introduces some changes to the bitindex to make this faster.
1. when selecting from a range, only the blocks and superblocks in that range are considered.
2. Selecting from the full index is now implemented through range selection rather than the other way around.
3. When the range from which we're selecting is entirely in the same cache line, a linear scan is performed rather than a binary search.
4. Some asserts are now debug_asserts and therefore no longer happen in production code.