### PR TITLE
Pre-allocate vectors instead of growing them dynamically

### DIFF
--- a/src/layer/internal/mod.rs
+++ b/src/layer/internal/mod.rs
@@ -17,37 +17,6 @@ pub use predicate_iterator::*;
 pub use rollup::*;
 pub use subject_iterator::*;
 
-/*
-fn external_id_to_internal(array_option: Option<&MonotonicLogArray>, id: u64) -> Option<u64> {
-    if id == 0 {
-        return None;
-    }
-
-    match array_option {
-        Some(array) => array.index_of(id).map(|mapped| mapped as u64 + 1),
-        None => Some(id),
-    }
-}
-
-fn internal_id_to_external(array_option: Option<&MonotonicLogArray>, id: u64) -> u64 {
-    match array_option {
-        Some(array) => array.entry((id - 1).try_into().unwrap()),
-        None => id,
-    }
-}
-
-fn id_iter(
-    array_option: Option<&MonotonicLogArray>,
-    adjacency_list_option: Option<&AdjacencyList>,
-) -> Box<dyn Iterator<Item = u64>> {
-    match (array_option, adjacency_list_option) {
-        (Some(array), _) => Box::new(array.iter()),
-        (_, Some(adjacency_list)) => Box::new(1..(adjacency_list.left_count() as u64 + 1)),
-        _ => Box::new(std::iter::empty()),
-    }
-}
-*/
-
 #[derive(Clone)]
 pub enum InternalLayer {
     Base(BaseLayer),
@@ -80,6 +49,17 @@ impl InternalLayer {
             Child(child) => Some(&*child.parent),
             Rollup(rollup) => rollup.internal.immediate_parent(),
         }
+    }
+
+    pub fn layer_stack_size(&self) -> usize {
+        let mut count = 1;
+        let mut l = self;
+        while let Some(p) = l.immediate_parent() {
+            l = p;
+            count += 1;
+        }
+
+        count
     }
 
     pub fn node_dictionary(&self) -> &PfcDict {

--- a/src/layer/internal/object_iterator.rs
+++ b/src/layer/internal/object_iterator.rs
@@ -149,8 +149,9 @@ pub struct InternalTripleObjectIterator {
 
 impl InternalTripleObjectIterator {
     pub fn from_layer(layer: &InternalLayer) -> Self {
-        let mut positives = Vec::new();
-        let mut negatives = Vec::new();
+        let stack_size = layer.layer_stack_size();
+        let mut positives = Vec::with_capacity(stack_size);
+        let mut negatives = Vec::with_capacity(stack_size);
         positives.push(layer.internal_triple_additions_by_object());
         negatives.push(layer.internal_triple_removals_by_object());
 

--- a/src/layer/internal/predicate_iterator.rs
+++ b/src/layer/internal/predicate_iterator.rs
@@ -114,17 +114,17 @@ impl Iterator for OptInternalLayerTriplePredicateIterator {
     }
 }
 
-#[derive(Clone)]
+//#[derive(Clone)]
 pub struct InternalTriplePredicateIterator {
-    predicate: u64,
     positives: Vec<OptInternalLayerTriplePredicateIterator>,
     negatives: Vec<OptInternalLayerTriplePredicateIterator>,
 }
 
 impl InternalTriplePredicateIterator {
     pub fn from_layer(layer: &InternalLayer, predicate: u64) -> Self {
-        let mut positives = Vec::new();
-        let mut negatives = Vec::new();
+        let stack_size = layer.layer_stack_size();
+        let mut positives = Vec::with_capacity(stack_size);
+        let mut negatives = Vec::with_capacity(stack_size);
         positives.push(layer.internal_triple_additions_p(predicate));
         negatives.push(layer.internal_triple_removals_p(predicate));
 
@@ -138,7 +138,6 @@ impl InternalTriplePredicateIterator {
         }
 
         Self {
-            predicate,
             positives,
             negatives,
         }

--- a/src/layer/internal/predicate_iterator.rs
+++ b/src/layer/internal/predicate_iterator.rs
@@ -114,7 +114,6 @@ impl Iterator for OptInternalLayerTriplePredicateIterator {
     }
 }
 
-//#[derive(Clone)]
 pub struct InternalTriplePredicateIterator {
     positives: Vec<OptInternalLayerTriplePredicateIterator>,
     negatives: Vec<OptInternalLayerTriplePredicateIterator>,

--- a/src/layer/internal/subject_iterator.rs
+++ b/src/layer/internal/subject_iterator.rs
@@ -221,8 +221,10 @@ pub struct InternalTripleSubjectIterator {
 
 impl InternalTripleSubjectIterator {
     pub fn from_layer(layer: &InternalLayer) -> Self {
-        let mut positives = Vec::new();
-        let mut negatives = Vec::new();
+        let stack_size = layer.layer_stack_size();
+        let mut positives = Vec::with_capacity(stack_size);
+        let mut negatives = Vec::with_capacity(stack_size);
+
         positives.push(layer.internal_triple_additions());
         negatives.push(layer.internal_triple_removals());
 
@@ -326,8 +328,9 @@ impl InternalTripleStackIterator {
         layer: &InternalLayer,
         parent_id: [u32; 5],
     ) -> Result<Self, LayerStackError> {
-        let mut positives = Vec::new();
-        let mut negatives = Vec::new();
+        let stack_size = layer.layer_stack_size();
+        let mut positives = Vec::with_capacity(stack_size);
+        let mut negatives = Vec::with_capacity(stack_size);
         positives.push(layer.internal_triple_additions());
         negatives.push(layer.internal_triple_removals());
 
@@ -343,6 +346,9 @@ impl InternalTripleStackIterator {
         if layer_opt.is_none() || layer_opt.unwrap().name() != parent_id {
             return Err(LayerStackError::ParentNotFound);
         }
+
+        positives.shrink_to_fit();
+        negatives.shrink_to_fit();
 
         Ok(Self {
             positives,


### PR DESCRIPTION
Various places in the code were allocating vectors that'd have to be grown at a later point, which could incur a full move of the existing array data to a new location in memory, incurring quite some overhead. This is now avoided by ensuring vectors are pre-allocated with the right size.