### PR TITLE
Introduce method for quickly looking up a single triple when subject and predicate are known

### DIFF
--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -639,6 +639,10 @@ impl Layer for StoreLayer {
     fn all_counts(&self) -> LayerCounts {
         self.layer.all_counts()
     }
+
+    fn single_triple_sp(&self, subject: u64, predicate: u64) -> Option<IdTriple> {
+        self.layer.single_triple_sp(subject, predicate)
+    }
 }
 
 /// A named graph in terminus-store.

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -439,6 +439,10 @@ impl Layer for SyncStoreLayer {
     fn all_counts(&self) -> LayerCounts {
         self.inner.all_counts()
     }
+
+    fn single_triple_sp(&self, subject: u64, predicate: u64) -> Option<IdTriple> {
+        self.inner.single_triple_sp(subject, predicate)
+    }
 }
 
 /// A named graph in terminus-store.


### PR DESCRIPTION
There are some cases where we very quickly want to look up a single triple based on a subject and a predicate. A major place where this comes up is when type checking, as we always expect just a single triple to match `t(id, rdf:type, Type)`. Other examples are list cells where we always expect a single `rdf:first` and `rdf:rest`, or arrays where we always expect a single `sys:index` and `sys:value`.

Avoiding setting up a full iterator in those cases makes code go faster. So even though it's a bit of a special case, having a function just for this makes sense.