### PR TITLE
Enable arm64 testing in CI

### DIFF
--- a/.github/workflows/other_platforms.yml
+++ b/.github/workflows/other_platforms.yml
@@ -1,0 +1,33 @@
+name: Run tests on other platforms
+
+on:
+  schedule:
+    - cron:  '45 1 * * *'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  build-and-test-arm64:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: uraimo/run-on-arch-action@v2
+      name: Run tests on arm64
+      id: build
+      with:
+        arch: aarch64
+        distro: bullseye
+        dockerRunArgs: |
+            --volume "${PWD}:/app"
+        run: |
+          apt-get update -q -y
+          apt install curl git build-essential -q -y
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source "$HOME/.cargo/env"
+          cd /app
+          export CARGO_NET_GIT_FETCH_WITH_CLI=true
+          cargo test --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,6 @@ jobs:
           apt-get update -q -y
           apt install curl -q -y
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          export PATH="${PATH}:/root/.cargo/bin"
+          source "$HOME/.cargo/env"
           cd /app
           cargo test --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        include:
-          os:ubuntu-latest, macos-latest, windows-latest]
+          os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,24 +35,23 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - run: which cargo
+    - name: Update the cargo index (because it crashes on arm64)
+      run: cargo install empty-library || true
 
-#    - name: Update the cargo index (because it crashes on arm64)
-#      run: cargo install empty-library || true
-
-#    - uses: uraimo/run-on-arch-action@v2
-#      name: Run tests on arm64
-#      id: build
-#      with:
-#        arch: aarch64
-#        distro: bullseye
-#        dockerRunArgs: |
-#            --volume "${PWD}:/app" --volume "${HOME}/.cargo/registry":/root/.cargo/registry
-#        run: |
-#          echo "THIS IS THE HOME DIR: $HOME"
-#          apt-get update -q -y
-#          apt install curl git -q -y
-#          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-#          source "$HOME/.cargo/env"
-#          cd /app
-#          cargo test --verbose
+    - uses: uraimo/run-on-arch-action@v2
+      name: Run tests on arm64
+      id: build
+      with:
+        arch: aarch64
+        distro: bullseye
+        dockerRunArgs: |
+            --volume "${PWD}:/app" --volume "${HOME}/.cargo/registry":/root/.cargo/registry
+        run: |
+          echo "THIS IS THE HOME DIR: $HOME"
+          ls /root/.cargo/registry
+          apt-get update -q -y
+          apt install curl git -q -y
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source "$HOME/.cargo/env"
+          cd /app
+          cargo test --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,9 @@ jobs:
       id: build
       with:
         arch: aarch64
-        distro: ubuntu_latest
+        distro: bullseye
         dockerRunArgs: |
-            --volume "${PWD}:/app" -m 4G
+            --volume "${PWD}:/app"
         run: |
           apt-get update -q -y
           apt install curl -q -y

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Update the cargo index (because it crashes on arm64)
-      run: cargo install empty-library || true
+#    - name: Update the cargo index (because it crashes on arm64)
+#      run: cargo install empty-library || true
 
     - uses: uraimo/run-on-arch-action@v2
       name: Run tests on arm64
@@ -47,9 +47,10 @@ jobs:
         dockerRunArgs: |
             --volume "${PWD}:/app" --volume "${HOME}/.cargo/registry":/root/.cargo/registry
         run: |
-          apt-get update -q -y
-          apt install curl git -q -y
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          source "$HOME/.cargo/env"
-          cd /app
-          cargo test --verbose
+          echo "THIS IS THE HOME DIR: $HOME"
+#          apt-get update -q -y
+#          apt install curl git -q -y
+#          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+#          source "$HOME/.cargo/env"
+#          cd /app
+#          cargo test --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-          os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,5 +48,4 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           export PATH="${PATH}:/root/.cargo/bin"
           cd /app
-          cargo package --verbose
           cargo test --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         arch: aarch64
         distro: ubuntu_latest
         dockerRunArgs: |
-            --volume "${PWD}:/app"
+            --volume "${PWD}:/app" -m 4G
         run: |
           apt-get update -q -y
           apt install curl -q -y

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,19 +35,21 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - run: which cargo
+
 #    - name: Update the cargo index (because it crashes on arm64)
 #      run: cargo install empty-library || true
 
-    - uses: uraimo/run-on-arch-action@v2
-      name: Run tests on arm64
-      id: build
-      with:
-        arch: aarch64
-        distro: bullseye
-        dockerRunArgs: |
-            --volume "${PWD}:/app" --volume "${HOME}/.cargo/registry":/root/.cargo/registry
-        run: |
-          echo "THIS IS THE HOME DIR: $HOME"
+#    - uses: uraimo/run-on-arch-action@v2
+#      name: Run tests on arm64
+#      id: build
+#      with:
+#        arch: aarch64
+#        distro: bullseye
+#        dockerRunArgs: |
+#            --volume "${PWD}:/app" --volume "${HOME}/.cargo/registry":/root/.cargo/registry
+#        run: |
+#          echo "THIS IS THE HOME DIR: $HOME"
 #          apt-get update -q -y
 #          apt install curl git -q -y
 #          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,8 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          os:ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -29,3 +30,24 @@ jobs:
     - name: Check code format
       if: matrix.os == 'ubuntu-latest' # No need to do this on every OS.
       run: cargo fmt -- --check
+
+  build-and-test-arm64:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: uraimo/run-on-arch-action@v2
+      name: Run tests on arm64
+      id: build
+      with:
+        arch: aarch64
+        distro: ubuntu_latest
+        dockerRunArgs: |
+            --volume "${PWD}:/app"
+        run: |
+          apt-get update -q -y
+          apt install curl
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          export PATH="${PATH}:/root/.cargo/bin"
+          cd /app
+          cargo package --verbose
+          cargo test --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
             --volume "${PWD}:/app"
         run: |
           apt-get update -q -y
-          apt install curl
+          apt install curl -q -y
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           export PATH="${PATH}:/root/.cargo/bin"
           cd /app

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
             --volume "${PWD}:/app"
         run: |
           apt-get update -q -y
-          apt install curl -q -y
+          apt install curl git -q -y
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           source "$HOME/.cargo/env"
           cd /app

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Update the cargo index (because it crashes on arm64)
-      run: cargo install empty-library
+      run: cargo install empty-library || true
 
     - uses: uraimo/run-on-arch-action@v2
       name: Run tests on arm64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,11 +47,10 @@ jobs:
         dockerRunArgs: |
             --volume "${PWD}:/app" --volume "${HOME}/.cargo/registry":/root/.cargo/registry
         run: |
-          echo "THIS IS THE HOME DIR: $HOME"
-          ls /root/.cargo/registry
           apt-get update -q -y
           apt install curl git -q -y
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           source "$HOME/.cargo/env"
           cd /app
+          export CARGO_NET_GIT_FETCH_WITH_CLI=true
           cargo test --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Update the cargo index (because it crashes on arm64)
-      run: cargo install empty-library || true
-
     - uses: uraimo/run-on-arch-action@v2
       name: Run tests on arm64
       id: build
@@ -48,7 +45,7 @@ jobs:
             --volume "${PWD}:/app" --volume "${HOME}/.cargo/registry":/root/.cargo/registry
         run: |
           apt-get update -q -y
-          apt install curl git -q -y
+          apt install curl git build-essential -q -y
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           source "$HOME/.cargo/env"
           cd /app

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+
+    - name: Update the cargo index (because it crashes on arm64)
+      run: cargo install empty-library
+
     - uses: uraimo/run-on-arch-action@v2
       name: Run tests on arm64
       id: build
@@ -41,7 +45,7 @@ jobs:
         arch: aarch64
         distro: bullseye
         dockerRunArgs: |
-            --volume "${PWD}:/app"
+            --volume "${PWD}:/app" --volume "${HOME}/.cargo/registry":/root/.cargo/registry
         run: |
           apt-get update -q -y
           apt install curl git -q -y

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,25 +29,3 @@ jobs:
     - name: Check code format
       if: matrix.os == 'ubuntu-latest' # No need to do this on every OS.
       run: cargo fmt -- --check
-
-  build-and-test-arm64:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-
-    - uses: uraimo/run-on-arch-action@v2
-      name: Run tests on arm64
-      id: build
-      with:
-        arch: aarch64
-        distro: bullseye
-        dockerRunArgs: |
-            --volume "${PWD}:/app" --volume "${HOME}/.cargo/registry":/root/.cargo/registry
-        run: |
-          apt-get update -q -y
-          apt install curl git build-essential -q -y
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          source "$HOME/.cargo/env"
-          cd /app
-          export CARGO_NET_GIT_FETCH_WITH_CLI=true
-          cargo test --verbose


### PR DESCRIPTION
This enables ARM64 testing in CI. All the tests pass.

Unfortunately I have to run it in QEMU since Github has no available ARM64 machines. It therefore runs very slowly, it takes almost 35 minutes to compile. Hence why I added a nightly cron instead of running it on every push and PR.

Also, please squash this PR since it contains a lot of experiments and I don't want to pollute the commit history.