### PR TITLE
Call finalize on layers after unpacking them

### DIFF
--- a/src/storage/pack.rs
+++ b/src/storage/pack.rs
@@ -124,6 +124,11 @@ impl<T: PersistentLayerStore> Packable for T {
                 }
             }
 
+            for layer_id in layer_id_set {
+                let layer_id_arr = string_to_name(&layer_id).unwrap();
+                handle.block_on(self.finalize_layer(layer_id_arr))?;
+            }
+
             Ok(())
         })
     }


### PR DESCRIPTION
on unpack, we were not finalizing layers. This is required however for the archive store to work properly, as otherwise layers are never moved from memory into persistent storage.

This pull adds a finalization step to unpack.