### PR TITLE
Layer load store backend with lru caching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ chrono = "0.4"
 base64 = "0.13"
 hex = "0.4"
 regex = "1.5"
+lru = "0.10"
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
 use crate::layer::{IdTriple, Layer, LayerBuilder, LayerCounts, ObjectType, ValueTriple};
-use crate::storage::archive::{ArchiveLayerStore, DirectoryArchiveLayerStoreBackend};
+use crate::storage::archive::{ArchiveLayerStore, DirectoryArchiveBackend};
 use crate::storage::directory::{DirectoryLabelStore, DirectoryLayerStore};
 use crate::storage::memory::{MemoryLabelStore, MemoryLayerStore};
 use crate::storage::{CachedLayerStore, LabelStore, LayerStore, LockingHashMapLayerCache};
@@ -882,10 +882,10 @@ pub fn open_memory_store() -> Store {
 
 pub fn open_archive_store<P: Into<PathBuf>>(path: P) -> Store {
     let p = path.into();
-    let archive_backend = DirectoryArchiveLayerStoreBackend::new(p.clone());
+    let archive_backend = DirectoryArchiveBackend::new(p.clone());
     Store::new(
         DirectoryLabelStore::new(p.clone()),
-        CachedLayerStore::new(ArchiveLayerStore::<DirectoryArchiveLayerStoreBackend, DirectoryArchiveLayerStoreBackend>::new(archive_backend.clone(), archive_backend), LockingHashMapLayerCache::new()),
+        CachedLayerStore::new(ArchiveLayerStore::<DirectoryArchiveBackend, DirectoryArchiveBackend>::new(archive_backend.clone(), archive_backend), LockingHashMapLayerCache::new()),
     )
 }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -7,7 +7,9 @@ use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
 use crate::layer::{IdTriple, Layer, LayerBuilder, LayerCounts, ObjectType, ValueTriple};
-use crate::storage::archive::{ArchiveLayerStore, DirectoryArchiveBackend, LruMetadataArchiveBackend, LruArchiveBackend};
+use crate::storage::archive::{
+    ArchiveLayerStore, DirectoryArchiveBackend, LruArchiveBackend, LruMetadataArchiveBackend,
+};
 use crate::storage::directory::{DirectoryLabelStore, DirectoryLayerStore};
 use crate::storage::memory::{MemoryLabelStore, MemoryLayerStore};
 use crate::storage::{CachedLayerStore, LabelStore, LayerStore, LockingHashMapLayerCache};
@@ -884,10 +886,14 @@ pub fn open_archive_store<P: Into<PathBuf>>(path: P, cache_size: usize) -> Store
     let p = path.into();
     let directory_archive_backend = DirectoryArchiveBackend::new(p.clone());
     let archive_backend = LruArchiveBackend::new(directory_archive_backend.clone(), cache_size);
-    let archive_metadata_backend = LruMetadataArchiveBackend::new(directory_archive_backend.clone(), archive_backend.clone());
+    let archive_metadata_backend =
+        LruMetadataArchiveBackend::new(directory_archive_backend.clone(), archive_backend.clone());
     Store::new(
         DirectoryLabelStore::new(p.clone()),
-        CachedLayerStore::new(ArchiveLayerStore::new(archive_metadata_backend, archive_backend), LockingHashMapLayerCache::new()),
+        CachedLayerStore::new(
+            ArchiveLayerStore::new(archive_metadata_backend, archive_backend),
+            LockingHashMapLayerCache::new(),
+        ),
     )
 }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
 use crate::layer::{IdTriple, Layer, LayerBuilder, LayerCounts, ObjectType, ValueTriple};
-use crate::storage::archive::ArchiveLayerStore;
+use crate::storage::archive::{ArchiveLayerStore, DirectoryArchiveLayerStoreBackend};
 use crate::storage::directory::{DirectoryLabelStore, DirectoryLayerStore};
 use crate::storage::memory::{MemoryLabelStore, MemoryLayerStore};
 use crate::storage::{CachedLayerStore, LabelStore, LayerStore, LockingHashMapLayerCache};
@@ -882,9 +882,10 @@ pub fn open_memory_store() -> Store {
 
 pub fn open_archive_store<P: Into<PathBuf>>(path: P) -> Store {
     let p = path.into();
+    let archive_backend = DirectoryArchiveLayerStoreBackend::new(p.clone());
     Store::new(
         DirectoryLabelStore::new(p.clone()),
-        CachedLayerStore::new(ArchiveLayerStore::new(p), LockingHashMapLayerCache::new()),
+        CachedLayerStore::new(ArchiveLayerStore::<DirectoryArchiveLayerStoreBackend, DirectoryArchiveLayerStoreBackend>::new(archive_backend.clone(), archive_backend), LockingHashMapLayerCache::new()),
     )
 }
 

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -592,8 +592,8 @@ pub fn open_sync_directory_store<P: Into<PathBuf>>(path: P) -> SyncStore {
 }
 
 /// Open a store that stores its data in the given directory as archive files.
-pub fn open_sync_archive_store<P: Into<PathBuf>>(path: P) -> SyncStore {
-    SyncStore::wrap(open_archive_store(path))
+pub fn open_sync_archive_store<P: Into<PathBuf>>(path: P, cache_size: usize) -> SyncStore {
+    SyncStore::wrap(open_archive_store(path, cache_size))
 }
 
 #[cfg(test)]

--- a/src/structure/logarray.rs
+++ b/src/structure/logarray.rs
@@ -148,7 +148,11 @@ impl LogArrayError {
     /// The input buffer size should be at least the appropriate
     /// multiple of 8 to include the exact number of encoded elements
     /// plus the control word. It is allowed to be larger.
-    fn validate_len_and_width_trailing(input_buf_size: usize, len: u32, width: u8) -> Result<(), Self> {
+    fn validate_len_and_width_trailing(
+        input_buf_size: usize,
+        len: u32,
+        width: u8,
+    ) -> Result<(), Self> {
         if width > 64 {
             return Err(LogArrayError::WidthTooLarge(width));
         }
@@ -228,7 +232,10 @@ fn read_control_word(buf: &[u8], input_buf_size: usize) -> Result<(u32, u8), Log
 
 /// Read the length and bit width from the control word buffer. `buf` must start at the first word
 /// after the data buffer. `input_buf_size` is used for validation, where it is allowed to be larger than expected.
-fn read_control_word_trailing(buf: &[u8], input_buf_size: usize) -> Result<(u32, u8), LogArrayError> {
+fn read_control_word_trailing(
+    buf: &[u8],
+    input_buf_size: usize,
+) -> Result<(u32, u8), LogArrayError> {
     let len = BigEndian::read_u32(buf);
     let width = buf[4];
     LogArrayError::validate_len_and_width_trailing(input_buf_size, len, width)?;

--- a/src/structure/logarray.rs
+++ b/src/structure/logarray.rs
@@ -140,6 +140,35 @@ impl LogArrayError {
 
         Ok(())
     }
+
+    /// Validate the number of elements and bit width against the input buffer size.
+    ///
+    /// The bit width should no greater than 64 since each word is 64 bits.
+    ///
+    /// The input buffer size should be at least the appropriate
+    /// multiple of 8 to include the exact number of encoded elements
+    /// plus the control word. It is allowed to be larger.
+    fn validate_len_and_width_trailing(input_buf_size: usize, len: u32, width: u8) -> Result<(), Self> {
+        if width > 64 {
+            return Err(LogArrayError::WidthTooLarge(width));
+        }
+
+        // Calculate the expected input buffer size. This includes the control word.
+        // To avoid overflow, convert `len: u32` to `u64` and do the addition in `u64`.
+        let expected_buf_size = u64::from(len) * u64::from(width) + 127 >> 6 << 3;
+        let input_buf_size = u64::try_from(input_buf_size).unwrap();
+
+        if input_buf_size < expected_buf_size {
+            return Err(LogArrayError::UnexpectedInputBufferSize(
+                input_buf_size,
+                expected_buf_size,
+                len,
+                width,
+            ));
+        }
+
+        Ok(())
+    }
 }
 
 impl fmt::Display for LogArrayError {
@@ -197,6 +226,15 @@ fn read_control_word(buf: &[u8], input_buf_size: usize) -> Result<(u32, u8), Log
     Ok((len, width))
 }
 
+/// Read the length and bit width from the control word buffer. `buf` must start at the first word
+/// after the data buffer. `input_buf_size` is used for validation, where it is allowed to be larger than expected.
+fn read_control_word_trailing(buf: &[u8], input_buf_size: usize) -> Result<(u32, u8), LogArrayError> {
+    let len = BigEndian::read_u32(buf);
+    let width = buf[4];
+    LogArrayError::validate_len_and_width_trailing(input_buf_size, len, width)?;
+    Ok((len, width))
+}
+
 fn logarray_length_from_len_width(len: u32, width: u8) -> usize {
     let num_bits = width as usize * len as usize;
     let num_u64 = num_bits / 64 + (if num_bits % 64 == 0 { 0 } else { 1 });
@@ -229,7 +267,7 @@ impl LogArray {
     pub fn parse_header_first(mut input_buf: Bytes) -> Result<(LogArray, Bytes), LogArrayError> {
         let input_buf_size = input_buf.len();
         LogArrayError::validate_input_buf_size(input_buf_size)?;
-        let (len, width) = read_control_word(&input_buf[..8], input_buf_size)?;
+        let (len, width) = read_control_word_trailing(&input_buf[..8], input_buf_size)?;
         let num_bytes = logarray_length_from_len_width(len, width);
         input_buf.advance(8);
         let rest = input_buf.split_off(num_bytes);


### PR DESCRIPTION
This refactors the archive layer store to use traits for the actual loading and storing of archive file. Additionally, it introduces an LRU cache mechanism to limit file lookups.