### PR TITLE
encode database labels using URL encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ base64 = "0.13"
 hex = "0.4"
 regex = "1.5"
 lru = "0.10"
+urlencoding = "2.1.2"
 
 [dev-dependencies]
 tempfile = "3.1"


### PR DESCRIPTION
Often database label (named graph names) needs to be a URI, however this conflicts with file system when directory store is used. A proposed solution is to encode the label using URL encoding, it is also backwards compatible.