### PR TITLE
delete unused dict entries in a squash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ base64 = "0.13"
 hex = "0.4"
 regex = "1.5"
 lru = "0.10"
-fnv = "1.0"
+bitvec = "1.0"
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ base64 = "0.13"
 hex = "0.4"
 regex = "1.5"
 lru = "0.10"
+fnv = "1.0"
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/src/storage/archive.rs
+++ b/src/storage/archive.rs
@@ -1417,7 +1417,7 @@ impl<M: ArchiveMetadataBackend + Unpin + 'static, D: ArchiveBackend + 'static> P
 
         let offsets_buf = offsets.finalize_header_first();
 
-        let mut data_buf = BytesMut::with_capacity(tally+8+offsets_buf.len());
+        let mut data_buf = BytesMut::with_capacity(tally + 8 + offsets_buf.len());
         data_buf.put_u64(presence_header.inner());
         data_buf.extend(offsets_buf);
         for (_file_type, data) in files {

--- a/src/storage/archive.rs
+++ b/src/storage/archive.rs
@@ -126,6 +126,7 @@ impl ArchiveBackend for DirectoryArchiveBackend {
         let mut result = options.open(path).await?;
         let mut buf = Vec::new();
         result.read_to_end(&mut buf).await?;
+        buf.shrink_to_fit();
 
         Ok(buf.into())
     }
@@ -1416,7 +1417,7 @@ impl<M: ArchiveMetadataBackend + Unpin + 'static, D: ArchiveBackend + 'static> P
 
         let offsets_buf = offsets.finalize_header_first();
 
-        let mut data_buf = BytesMut::new();
+        let mut data_buf = BytesMut::with_capacity(tally);
         data_buf.put_u64(presence_header.inner());
         data_buf.extend(offsets_buf);
         for (_file_type, data) in files {

--- a/src/storage/archive.rs
+++ b/src/storage/archive.rs
@@ -1417,7 +1417,7 @@ impl<M: ArchiveMetadataBackend + Unpin + 'static, D: ArchiveBackend + 'static> P
 
         let offsets_buf = offsets.finalize_header_first();
 
-        let mut data_buf = BytesMut::with_capacity(tally);
+        let mut data_buf = BytesMut::with_capacity(tally+8+offsets_buf.len());
         data_buf.put_u64(presence_header.inner());
         data_buf.extend(offsets_buf);
         for (_file_type, data) in files {

--- a/src/storage/layer.rs
+++ b/src/storage/layer.rs
@@ -1864,7 +1864,6 @@ impl<F: 'static + FileLoad + FileStore + Clone, T: 'static + PersistentLayerStor
         let mut pred_count = 0;
 
         for layer in stack {
-            nodes.reserve(layer.node_dictionary().num_entries());
             nodes.extend(
                 layer
                     .node_dictionary()
@@ -1880,7 +1879,6 @@ impl<F: 'static + FileLoad + FileStore + Clone, T: 'static + PersistentLayerStor
                         }
                     }),
             );
-            predicates.reserve(layer.predicate_dictionary().num_entries());
             predicates.extend(layer.predicate_dictionary().iter().enumerate().flat_map(
                 |(i, x)| {
                     let mapped_predicate =
@@ -1892,7 +1890,6 @@ impl<F: 'static + FileLoad + FileStore + Clone, T: 'static + PersistentLayerStor
                     }
                 },
             ));
-            values.reserve(layer.value_dictionary().num_entries());
             values.extend(
                 layer
                     .value_dictionary()

--- a/src/storage/layer.rs
+++ b/src/storage/layer.rs
@@ -1833,7 +1833,6 @@ impl<F: 'static + FileLoad + FileStore + Clone, T: 'static + PersistentLayerStor
         // then iterate over all id triples and map them
         // sort the mapped triples, insert them
         // finalize
-        println!("let's squash");
 
         let stack = layer.immediate_layers();
         let node_count: usize = stack.iter().map(|l|l.node_dictionary().num_entries()).sum();
@@ -1928,8 +1927,6 @@ impl<F: 'static + FileLoad + FileStore + Clone, T: 'static + PersistentLayerStor
         for (remapped, (_, old)) in predicates.iter().enumerate() {
             pred_map[*old as usize] = remapped as u64 + 1;
         }
-
-        eprintln!("map sizes: {} ({}) {} ({})", node_value_map.len(), node_value_map.len()*8, pred_map.len(), pred_map.len()*8);
 
         let layer_name = self.create_directory().await?;
         let base_layer_files = self.base_layer_files(layer_name).await?;

--- a/src/storage/layer.rs
+++ b/src/storage/layer.rs
@@ -1852,7 +1852,7 @@ impl<F: 'static + FileLoad + FileStore + Clone, T: 'static + PersistentLayerStor
         }
 
         for layer in stack {
-            let mapped_nodes: Vec<_> = layer
+            nodes.extend(layer
                 .node_dictionary()
                 .iter()
                 .enumerate()
@@ -1864,9 +1864,8 @@ impl<F: 'static + FileLoad + FileStore + Clone, T: 'static + PersistentLayerStor
                     } else {
                         None
                     }
-                })
-                .collect();
-            let mapped_predicates: Vec<_> = layer
+                }));
+            predicates.extend(layer
                 .predicate_dictionary()
                 .iter()
                 .enumerate()
@@ -1878,9 +1877,8 @@ impl<F: 'static + FileLoad + FileStore + Clone, T: 'static + PersistentLayerStor
                     } else {
                         None
                     }
-                })
-                .collect();
-            let mapped_values: Vec<_> = layer
+                }));
+            values.extend(layer
                 .value_dictionary()
                 .iter()
                 .enumerate()
@@ -1894,15 +1892,12 @@ impl<F: 'static + FileLoad + FileStore + Clone, T: 'static + PersistentLayerStor
                     } else {
                         None
                     }
-                })
-                .collect();
+                }));
+
             node_value_count += (layer.node_dictionary().num_entries()
                 + layer.value_dictionary().num_entries()) as u64;
             pred_count += layer.predicate_dictionary().num_entries() as u64;
 
-            nodes.extend(mapped_nodes);
-            predicates.extend(mapped_predicates);
-            values.extend(mapped_values);
         }
         nodes.sort();
         predicates.sort();

--- a/src/storage/layer.rs
+++ b/src/storage/layer.rs
@@ -2009,6 +2009,7 @@ impl<F: 'static + FileLoad + FileStore + Clone, T: 'static + PersistentLayerStor
         let mut num_triple_changes = 0;
         let layer_changes_upto = self.layer_changes_upto(layer.name(), upto).await?;
         for (change_type, triple) in layer_changes_upto.clone() {
+            num_triple_changes += 1;
             if change_type == TripleChange::Removal {
                 // removals can't possibly have dictionary entries
                 // that are part of this layer stack, as they are
@@ -2017,7 +2018,6 @@ impl<F: 'static + FileLoad + FileStore + Clone, T: 'static + PersistentLayerStor
                 // upto layer.
                 continue;
             }
-            num_triple_changes += 1;
             if triple.subject >= base_node_value_count {
                 node_value_existences.set((triple.subject - base_node_value_count) as usize, true);
             }

--- a/src/storage/layer.rs
+++ b/src/storage/layer.rs
@@ -2008,7 +2008,15 @@ impl<F: 'static + FileLoad + FileStore + Clone, T: 'static + PersistentLayerStor
         let mut predicate_existences = bitvec![0;stack_pred_count as usize+1];
         let mut num_triple_changes = 0;
         let layer_changes_upto = self.layer_changes_upto(layer.name(), upto).await?;
-        for (_, triple) in layer_changes_upto.clone() {
+        for (change_type, triple) in layer_changes_upto.clone() {
+            if change_type == TripleChange::Removal {
+                // removals can't possibly have dictionary entries
+                // that are part of this layer stack, as they are
+                // relative to upto, and therefore cannot contain
+                // dictionary entries that didn't yet exist for the
+                // upto layer.
+                continue;
+            }
             num_triple_changes += 1;
             if triple.subject >= base_node_value_count {
                 node_value_existences.set((triple.subject - base_node_value_count) as usize, true);

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1561,7 +1561,7 @@ mod tests {
         assert_eq!(
             vec![
                 ValueTriple::new_node("foo", "bar", "baz"),
-                ValueTriple::new_string_value("foo", "bar", "hai"),
+                ValueTriple::new_string_value("foo", "baz", "hai"),
             ],
             all_triple_removals
         );

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1404,6 +1404,170 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn squash_and_forget_dict_entries() {
+        let store = open_memory_store();
+        let builder = store.create_base_layer().await.unwrap();
+        builder
+            .add_value_triple(ValueTriple::new_node("a", "b", "anode"))
+            .unwrap();
+        builder
+            .add_value_triple(ValueTriple::new_string_value("a", "b", "astring"))
+            .unwrap();
+        builder
+            .add_value_triple(ValueTriple::new_node("a", "c", "anothernode"))
+            .unwrap();
+        builder
+            .add_value_triple(ValueTriple::new_string_value("a", "c", "anotherstring"))
+            .unwrap();
+
+        let base_layer = builder.commit().await.unwrap();
+
+        let builder = base_layer.open_write().await.unwrap();
+        builder
+            .remove_value_triple(ValueTriple::new_node("a", "c", "anothernode"))
+            .unwrap();
+        builder
+            .remove_value_triple(ValueTriple::new_string_value("a", "c", "anotherstring"))
+            .unwrap();
+        let child_layer = builder.commit().await.unwrap();
+
+        let squashed = child_layer.squash().await.unwrap();
+        // annoyingly we need to get the internal layer version, so lets re-retrieve
+        let squashed = store
+            .layer_store
+            .get_layer(squashed.name())
+            .await
+            .unwrap()
+            .unwrap();
+        let nodes: Vec<_> = squashed
+            .node_dictionary()
+            .iter()
+            .map(|b| b.to_bytes())
+            .collect();
+        assert_eq!(vec![b"a" as &[u8], b"anode"], nodes);
+        let preds: Vec<_> = squashed
+            .predicate_dictionary()
+            .iter()
+            .map(|b| b.to_bytes())
+            .collect();
+        assert_eq!(vec![b"b" as &[u8]], preds);
+        let vals: Vec<_> = squashed
+            .value_dictionary()
+            .iter()
+            .map(|b| b.to_bytes())
+            .collect();
+        assert_eq!(vec![b"astring" as &[u8]], vals);
+
+        let all_triples: Vec<_> = squashed
+            .triples()
+            .map(|t| squashed.id_triple_to_string(&t).unwrap())
+            .collect();
+        assert_eq!(
+            vec![
+                ValueTriple::new_node("a", "b", "anode"),
+                ValueTriple::new_string_value("a", "b", "astring"),
+            ],
+            all_triples
+        );
+    }
+
+    #[tokio::test]
+    async fn squash_upto_and_forget_dict_entries() {
+        let store = open_memory_store();
+        let builder = store.create_base_layer().await.unwrap();
+        builder
+            .add_value_triple(ValueTriple::new_node("foo", "bar", "baz"))
+            .unwrap();
+        builder
+            .add_value_triple(ValueTriple::new_node("baz", "bar", "quux"))
+            .unwrap();
+        builder
+            .add_value_triple(ValueTriple::new_string_value("foo", "baz", "hai"))
+            .unwrap();
+        let base_layer = builder.commit().await.unwrap();
+        let builder = base_layer.open_write().await.unwrap();
+        builder
+            .remove_value_triple(ValueTriple::new_string_value("foo", "baz", "hai"))
+            .unwrap();
+        builder
+            .add_value_triple(ValueTriple::new_node("a", "b", "anode"))
+            .unwrap();
+        builder
+            .add_value_triple(ValueTriple::new_string_value("a", "b", "astring"))
+            .unwrap();
+        builder
+            .add_value_triple(ValueTriple::new_node("a", "c", "anothernode"))
+            .unwrap();
+        builder
+            .add_value_triple(ValueTriple::new_string_value("a", "c", "anotherstring"))
+            .unwrap();
+
+        let child_layer1 = builder.commit().await.unwrap();
+
+        let builder = child_layer1.open_write().await.unwrap();
+        builder
+            .remove_value_triple(ValueTriple::new_node("foo", "bar", "baz"))
+            .unwrap();
+        builder
+            .remove_value_triple(ValueTriple::new_node("a", "c", "anothernode"))
+            .unwrap();
+        builder
+            .remove_value_triple(ValueTriple::new_string_value("a", "c", "anotherstring"))
+            .unwrap();
+        let child_layer2 = builder.commit().await.unwrap();
+
+        let squashed = child_layer2.squash_upto(&base_layer).await.unwrap();
+        // annoyingly we need to get the internal layer version, so lets re-retrieve
+        let squashed = store
+            .layer_store
+            .get_layer(squashed.name())
+            .await
+            .unwrap()
+            .unwrap();
+        let nodes: Vec<_> = squashed
+            .node_dictionary()
+            .iter()
+            .map(|b| b.to_bytes())
+            .collect();
+        assert_eq!(vec![b"a" as &[u8], b"anode"], nodes);
+        let preds: Vec<_> = squashed
+            .predicate_dictionary()
+            .iter()
+            .map(|b| b.to_bytes())
+            .collect();
+        assert_eq!(vec![b"b" as &[u8]], preds);
+        let vals: Vec<_> = squashed
+            .value_dictionary()
+            .iter()
+            .map(|b| b.to_bytes())
+            .collect();
+        assert_eq!(vec![b"astring" as &[u8]], vals);
+
+        let all_triple_additions: Vec<_> = squashed
+            .internal_triple_additions()
+            .map(|t| squashed.id_triple_to_string(&t).unwrap())
+            .collect();
+        let all_triple_removals: Vec<_> = squashed
+            .internal_triple_removals()
+            .map(|t| squashed.id_triple_to_string(&t).unwrap())
+            .collect();
+        assert_eq!(
+            vec![
+                ValueTriple::new_node("a", "b", "anode"),
+                ValueTriple::new_string_value("a", "b", "astring"),
+            ],
+            all_triple_additions
+        );
+        assert_eq!(
+            vec![
+                ValueTriple::new_node("foo", "bar", "baz"),
+                ValueTriple::new_string_value("foo", "bar", "hai"),
+            ],
+            all_triple_removals
+        );
+    }
+
+    #[tokio::test]
     async fn apply_a_base_delta() {
         let store = open_memory_store();
         let builder = store.create_base_layer().await.unwrap();


### PR DESCRIPTION
In the squash refactor I forgot to make sure unused dict entries are deleted. This PR does a use check for all squashed dict entries and removes the ones that are unused.