### PR TITLE
use less memory in builders

### DIFF
--- a/benches/builder/main.rs
+++ b/benches/builder/main.rs
@@ -12,7 +12,7 @@ use data::*;
 #[bench]
 fn build_empty_base_layer(b: &mut Bencher) {
     let dir = tempdir().unwrap();
-    let store = terminus_store::open_sync_directory_store(dir.path());
+    let store = terminus_store::open_sync_archive_store(dir.path(), 512);
 
     b.iter(|| {
         let builder = store.create_base_layer().unwrap();
@@ -23,7 +23,7 @@ fn build_empty_base_layer(b: &mut Bencher) {
 #[bench]
 fn build_base_layer_1000(b: &mut Bencher) {
     let dir = tempdir().unwrap();
-    let store = terminus_store::open_sync_directory_store(dir.path());
+    let store = terminus_store::open_sync_archive_store(dir.path(), 512);
 
     let seed = b"the quick brown fox jumped over ";
     let rand = StdRng::from_seed(*seed);
@@ -48,7 +48,7 @@ fn build_base_layer_1000(b: &mut Bencher) {
 #[bench]
 fn build_empty_child_layer_on_empty_base_layer(b: &mut Bencher) {
     let dir = tempdir().unwrap();
-    let store = terminus_store::open_sync_directory_store(dir.path());
+    let store = terminus_store::open_sync_archive_store(dir.path(), 512);
     let builder = store.create_base_layer().unwrap();
     let base_layer = builder.commit().unwrap();
 
@@ -61,7 +61,7 @@ fn build_empty_child_layer_on_empty_base_layer(b: &mut Bencher) {
 #[bench]
 fn build_nonempty_child_layer_on_empty_base_layer(b: &mut Bencher) {
     let dir = tempdir().unwrap();
-    let store = terminus_store::open_sync_directory_store(dir.path());
+    let store = terminus_store::open_sync_archive_store(dir.path(), 512);
     let builder = store.create_base_layer().unwrap();
     let base_layer = builder.commit().unwrap();
 
@@ -88,7 +88,7 @@ fn build_nonempty_child_layer_on_empty_base_layer(b: &mut Bencher) {
 #[bench]
 fn build_nonempty_child_layer_on_nonempty_base_layer(b: &mut Bencher) {
     let dir = tempdir().unwrap();
-    let store = terminus_store::open_sync_directory_store(dir.path());
+    let store = terminus_store::open_sync_archive_store(dir.path(), 512);
 
     let seed = b"the quick brown fox jumped over ";
     let rand = StdRng::from_seed(*seed);

--- a/src/layer/simple_builder.rs
+++ b/src/layer/simple_builder.rs
@@ -258,7 +258,7 @@ impl<F: 'static + FileLoad + FileStore + Clone> LayerBuilder for SimpleLayerBuil
             }
             if addition.is_none() {
                 // loop over the remaining removals to nullify everything that should be a noop due to being out of range
-                while let Some(removal) = removals_it.next() {
+                for removal in removals_it {
                     if removal.subject > parent_node_value_offset as u64
                         || removal.predicate > parent_predicate_offset as u64
                         || removal.object > parent_node_value_offset as u64


### PR DESCRIPTION
This PR changes the simple builder to deduplicate strings. This ensures a much smaller memory footprint. It's also faster, despite not being multi-threaded anymore.

I might reintroduce multi-threading in some parts though.