### PR TITLE
Raise version to 0.21.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminus-store"
-version = "0.20.1"
+version = "0.21.0"
 authors = ["Matthijs van Otterdijk <matthijs@datachemist.com>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
Releasing now to prepare the release of TerminusDB with the memory use optimizations.