### PR TITLE
Add scientific notation to terminus store

### DIFF
--- a/src/structure/tfc/decimal.rs
+++ b/src/structure/tfc/decimal.rs
@@ -23,7 +23,7 @@ impl Decimal {
 
 pub fn validate_decimal(s: &str) -> Result<(), DecimalValidationError> {
     lazy_static! {
-        static ref RE: Regex = Regex::new(r"^-?\d+(\.\d+)?([eE@]-?\d+)?$").unwrap();
+        static ref RE: Regex = Regex::new(r"^-?\d+(\.\d+)?([eE@](-|\+)?\d+)?$").unwrap();
     }
     if RE.is_match(s) {
         Ok(())
@@ -114,7 +114,7 @@ pub fn decimal_to_storage(decimal: &str) -> Vec<u8> {
     lazy_static! {
         static ref STD: Regex = Regex::new(r"^-?\d+(\.\d*)?$").unwrap();
         static ref SCIENTIFIC: Regex = Regex::new(
-            r"^(?P<sign>-)?(?P<integer>\d+)(\.(?P<fraction>\d+))?([eE@](?P<exp>-?\d+))?$"
+            r"^(?P<sign>-)?(?P<integer>\d+)(\.(?P<fraction>\d+))?([eE@](?P<exp>(-|\+)?\d+))?$"
         )
         .unwrap();
     }

--- a/src/structure/tfc/decimal.rs
+++ b/src/structure/tfc/decimal.rs
@@ -23,7 +23,7 @@ impl Decimal {
 
 pub fn validate_decimal(s: &str) -> Result<(), DecimalValidationError> {
     lazy_static! {
-        static ref RE: Regex = Regex::new(r"-?\d+(\.\d+)?").unwrap();
+        static ref RE: Regex = Regex::new(r"^-?\d+(\.\d+)?([eE@]-?\d+)?$").unwrap();
     }
     if RE.is_match(s) {
         Ok(())
@@ -111,24 +111,71 @@ pub fn decode_fraction<B: Buf>(fraction_buf: &mut B, is_pos: bool) -> String {
 }
 
 pub fn decimal_to_storage(decimal: &str) -> Vec<u8> {
-    let mut parts = decimal.split('.');
-    let bigint = parts.next().unwrap_or(decimal);
-    let fraction = parts.next();
-    let integer_part = bigint.parse::<Integer>().unwrap();
-    let is_neg = decimal.starts_with('-');
-    integer_and_fraction_to_storage(is_neg, integer_part, fraction)
+    eprintln!("processing decimal {decimal}");
+    lazy_static! {
+        static ref STD: Regex = Regex::new(r"^-?\d+(\.\d*)?$").unwrap();
+        static ref SCIENTIFIC: Regex = Regex::new(
+            r"^(?P<sign>-)?(?P<integer>\d+)(\.(?P<fraction>\d+))?([eE@](?P<exp>-?\d+))?$"
+        )
+        .unwrap();
+    }
+    if STD.is_match(decimal) {
+        eprintln!("Standard mode");
+        let mut parts = decimal.split('.');
+        let bigint = parts.next().unwrap_or(decimal);
+        let fraction = parts.next();
+        let integer_part = bigint.parse::<Integer>().unwrap();
+        let is_neg = decimal.starts_with('-');
+        integer_and_fraction_to_storage(is_neg, integer_part, fraction)
+    } else {
+        let captures = SCIENTIFIC.captures(decimal).unwrap(); // prevalidated
+        let is_neg = captures.name("sign").is_some();
+        let exp: i32 = if let Some(exp_string) = captures.name("exp") {
+            exp_string.as_str().parse::<i32>().unwrap()
+        } else {
+            0_i32
+        };
+        let integer_str = captures.name("integer").map(|m| m.as_str()).unwrap();
+        let fraction_str = captures.name("fraction").map_or_else(|| "", |m| m.as_str());
+        let left_pad = if -exp > integer_str.len() as i32 {
+            "0.".to_string()
+                + &"0".repeat((-exp - integer_str.len() as i32).unsigned_abs() as usize)
+        } else {
+            "".to_string()
+        };
+        let right_pad = if exp > fraction_str.len() as i32 {
+            "0".repeat((exp - fraction_str.len() as i32) as usize)
+        } else {
+            "".to_string()
+        };
+        let left_len = left_pad.len() as i32 + integer_str.len() as i32;
+        let combined = left_pad + integer_str + fraction_str + &right_pad;
+        let shift = (left_len + exp) as usize;
+        let integer_str = &combined[0..shift];
+        let sign = if is_neg { -1 } else { 1 };
+        let integer_part = sign
+            * integer_str
+                .parse::<Integer>()
+                .unwrap_or_else(|_| Integer::from(0));
+        let fraction = &combined[shift..];
+        let fraction = if fraction.is_empty() {
+            None
+        } else {
+            Some(fraction)
+        };
+        integer_and_fraction_to_storage(is_neg, integer_part, fraction)
+    }
 }
 
 pub fn storage_to_decimal<B: Buf>(bytes: &mut B) -> String {
     let (int, is_pos) = storage_to_bigint_and_sign(bytes);
     let fraction = decode_fraction(bytes, is_pos);
-    let decimal = if fraction.is_empty() {
+    if fraction.is_empty() {
         format!("{int:}")
     } else {
         let sign = if int == 0 && !is_pos { "-" } else { "" };
         format!("{sign:}{int:}.{fraction:}")
-    };
-    decimal
+    }
 }
 
 pub fn integer_and_fraction_to_storage(
@@ -136,6 +183,7 @@ pub fn integer_and_fraction_to_storage(
     integer: Integer,
     fraction: Option<&str>,
 ) -> Vec<u8> {
+    eprintln!("is_neg: {is_neg}, integer: {integer}, fraction: {fraction:?}");
     let prefix = bigint_to_storage(integer.clone());
     let mut prefix = if integer == 0 && is_neg {
         vec![NEGATIVE_ZERO] // negative zero
@@ -144,8 +192,8 @@ pub fn integer_and_fraction_to_storage(
     };
     let suffix = if is_neg {
         let mut suffix = encode_fraction(fraction);
-        for i in 0..suffix.len() {
-            suffix[i] = !suffix[i]
+        for elt in &mut suffix {
+            *elt = !(*elt)
         }
         suffix
     } else {

--- a/src/structure/tfc/decimal.rs
+++ b/src/structure/tfc/decimal.rs
@@ -111,7 +111,6 @@ pub fn decode_fraction<B: Buf>(fraction_buf: &mut B, is_pos: bool) -> String {
 }
 
 pub fn decimal_to_storage(decimal: &str) -> Vec<u8> {
-    eprintln!("processing decimal {decimal}");
     lazy_static! {
         static ref STD: Regex = Regex::new(r"^-?\d+(\.\d*)?$").unwrap();
         static ref SCIENTIFIC: Regex = Regex::new(
@@ -120,7 +119,6 @@ pub fn decimal_to_storage(decimal: &str) -> Vec<u8> {
         .unwrap();
     }
     if STD.is_match(decimal) {
-        eprintln!("Standard mode");
         let mut parts = decimal.split('.');
         let bigint = parts.next().unwrap_or(decimal);
         let fraction = parts.next();
@@ -183,7 +181,6 @@ pub fn integer_and_fraction_to_storage(
     integer: Integer,
     fraction: Option<&str>,
 ) -> Vec<u8> {
-    eprintln!("is_neg: {is_neg}, integer: {integer}, fraction: {fraction:?}");
     let prefix = bigint_to_storage(integer.clone());
     let mut prefix = if integer == 0 && is_neg {
         vec![NEGATIVE_ZERO] // negative zero

--- a/src/structure/tfc/typed.rs
+++ b/src/structure/tfc/typed.rs
@@ -1086,6 +1086,7 @@ mod tests {
             Decimal::make_entry(&Decimal("-342343.234e20".to_string())),
             Decimal::make_entry(&Decimal("-342343.234e-12".to_string())),
             Decimal::make_entry(&Decimal("1.6021766208e-19".to_string())),
+            Decimal::make_entry(&Decimal("1.6021766208e+30".to_string())),
         ];
         let mut vec = entries.clone();
         let entry_two = Decimal::make_entry(&Decimal("-342343234".to_string()));
@@ -1150,6 +1151,10 @@ mod tests {
         assert_eq!(
             dict.entry(5).unwrap().as_val::<Decimal, String>(),
             "342343234".to_string()
+        );
+        assert_eq!(
+            dict.entry(6).unwrap().as_val::<Decimal, String>(),
+            "1602176620800000000000000000000".to_string()
         );
     }
 

--- a/src/structure/tfc/typed.rs
+++ b/src/structure/tfc/typed.rs
@@ -1079,6 +1079,81 @@ mod tests {
     }
 
     #[test]
+    fn test_scientific_floats() {
+        let entries: Vec<TypedDictEntry> = vec![
+            Decimal::make_entry(&Decimal("342343.234e3".to_string())),
+            Decimal::make_entry(&Decimal("-342343.234e3".to_string())),
+            Decimal::make_entry(&Decimal("-342343.234e20".to_string())),
+            Decimal::make_entry(&Decimal("-342343.234e-12".to_string())),
+            Decimal::make_entry(&Decimal("1.6021766208e-19".to_string())),
+        ];
+        let mut vec = entries.clone();
+        let entry_two = Decimal::make_entry(&Decimal("-342343234".to_string()));
+        let sci_entry_two = Decimal::make_entry(&Decimal("-342343.234e3".to_string()));
+        assert_eq!(entry_two, sci_entry_two);
+        let entry_four = Decimal::make_entry(&Decimal("-0.000000342343234".to_string()));
+        assert!(entry_two < entry_four);
+        assert!(entries[3] < entries[4]);
+        assert!(entries[2] < entries[3]);
+        assert!(entries[2] < entries[4]);
+        vec.sort();
+
+        let used_types_buf = BytesMut::new();
+        let type_offsets_buf = BytesMut::new();
+        let block_offsets_buf = BytesMut::new();
+        let data_buf = BytesMut::new();
+
+        let mut typed_builder = TypedDictBufBuilder::new(
+            used_types_buf,
+            type_offsets_buf,
+            block_offsets_buf,
+            data_buf,
+        );
+
+        let _results: Vec<u64> = vec
+            .clone()
+            .into_iter()
+            .map(|entry| typed_builder.add(entry))
+            .collect();
+
+        let (used_types, type_offsets, block_offsets, data) = typed_builder.finalize();
+
+        let dict = TypedDict::from_parts(
+            used_types.freeze(),
+            type_offsets.freeze(),
+            block_offsets.freeze(),
+            data.freeze(),
+        );
+
+        for (i, item) in vec.iter().enumerate() {
+            assert_eq!(*item, dict.entry(i + 1).unwrap())
+        }
+
+        assert_eq!(
+            dict.entry(1).unwrap().as_val::<Decimal, String>(),
+            "-34234323400000000000000000".to_string()
+        );
+        assert_eq!(
+            dict.entry(2).unwrap().as_val::<Decimal, String>(),
+            "-342343234".to_string()
+        );
+        assert_eq!(
+            dict.entry(3).unwrap().as_val::<Decimal, String>(),
+            "-0.000000342343234".to_string()
+        );
+        assert_eq!(-0.000000342343234, -342343.234e-12);
+        assert_eq!(
+            dict.entry(4).unwrap().as_val::<Decimal, String>(),
+            "0.00000000000000000016021766208".to_string()
+        );
+        assert_eq!(0.00000000000000000016021766208, 1.6021766208e-19);
+        assert_eq!(
+            dict.entry(5).unwrap().as_val::<Decimal, String>(),
+            "342343234".to_string()
+        );
+    }
+
+    #[test]
     fn test_two_blocks() {
         let mut vec: Vec<TypedDictEntry> = vec![
             String::make_entry(&"fdsa"),


### PR DESCRIPTION
Currently we do not support normal XSD decimal notation which can use scientific notation. I've extended the parser to do this correctly.