### PR TITLE
Fix id_object_is_node

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,7 +2,6 @@
 extern crate test;
 
 use tempfile::tempdir;
-use terminus_store;
 use terminus_store::layer::ValueTriple;
 use test::Bencher;
 

--- a/benches/builder/main.rs
+++ b/benches/builder/main.rs
@@ -4,7 +4,6 @@ mod data;
 
 use rand::prelude::*;
 use tempfile::tempdir;
-use terminus_store;
 use test::Bencher;
 
 use data::*;

--- a/src/layer/builder.rs
+++ b/src/layer/builder.rs
@@ -6,7 +6,7 @@ use rayon::prelude::*;
 
 use super::layer::*;
 use crate::{chrono_log, storage::*};
-use tdb_succinct::util::{self, heap_sorted_iter, stream_iter_ok};
+use tdb_succinct::util::{heap_sorted_iter, stream_iter_ok};
 use tdb_succinct::*;
 
 pub struct DictionarySetFileBuilder<F: 'static + FileLoad + FileStore> {

--- a/src/layer/simple_builder.rs
+++ b/src/layer/simple_builder.rs
@@ -428,7 +428,6 @@ impl<F: 'static + FileLoad + FileStore + Clone> LayerBuilder for SimpleLayerBuil
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::layer::internal::InternalLayer;
     use crate::storage::memory::*;
     use tdb_succinct::TdbDataType;
 

--- a/src/storage/delta.rs
+++ b/src/storage/delta.rs
@@ -1,7 +1,5 @@
 use std::io;
 
-use tfc::file::{merge_string_dictionaries, merge_typed_dictionaries};
-
 use crate::layer::builder::{build_indexes, TripleFileBuilder};
 use crate::layer::*;
 use crate::storage::*;

--- a/src/storage/directory.rs
+++ b/src/storage/directory.rs
@@ -460,7 +460,6 @@ impl LabelStore for CachedDirectoryLabelStore {
 mod tests {
     use super::*;
     use crate::layer::*;
-    use std::sync::Arc;
     use tempfile::tempdir;
 
     #[tokio::test]

--- a/src/storage/layer.rs
+++ b/src/storage/layer.rs
@@ -2651,11 +2651,10 @@ pub(crate) async fn file_triple_layer_count<F: FileLoad + FileStore>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::layer::{Layer, ObjectType, ValueTriple};
+    use crate::layer::{ObjectType, ValueTriple};
     use crate::storage::directory::DirectoryLayerStore;
     use crate::storage::memory::MemoryLayerStore;
     use std::collections::HashMap;
-    use std::io;
     use tempfile::{tempdir, TempDir};
     // these tests are for both the memory store and the directory store
     // They test functionality that should really work for both


### PR DESCRIPTION
`id_object_is_node` had an edge case where it'd return None for cases where it should have returned a Some, causing processes that depended on the direct behavior to panic.

This replaces the implementation with a replica of `id_object` minus the dictionary lookup. Assuming `id_object` is correct, `id_object_is_node` (and by extension `id_object_is_value`) will now also be correct.